### PR TITLE
Explicitly add EventHeader conversion

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -129,6 +129,7 @@ if CONFIG["InputMode"] == "EDM4hep":
     EDM4hep2Lcio = EDM4hep2LcioTool("EDM4hep2Lcio")
     EDM4hep2Lcio.convertAll = False
     EDM4hep2Lcio.collNameMapping = {
+        'EventHeader':                     'EventHeader',
         'MCParticles':                     'MCParticle',
         'VertexBarrelCollection':          'VertexBarrelCollection',
         'VertexEndcapCollection':          'VertexEndcapCollection',


### PR DESCRIPTION

BEGINRELEASENOTES
- Add explicit EventHeader conversion to not run into https://github.com/key4hep/k4MarlinWrapper/issues/110 again

ENDRELEASENOTES
