### PR TITLE
Note that evtMax setting can be overridden by k4run.

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -58,17 +58,14 @@ cellIDSvc.OutputLevel = INFO
 svcList.append(cellIDSvc)
 
 output_basename = "output"
-evtMax = 3
 
 from k4FWCore.parseArgs import parser
 parser.add_argument("--inputFiles", action="extend", nargs="+", metavar=("file1", "file2"), help="One or multiple input files")
 parser.add_argument("--outputBasename", help="Basename of the output file(s)", default=output_basename)
 parser.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
-parser.add_argument("--evtMax", help="Number of events to process", default=evtMax)
 my_opts = parser.parse_known_args()[0]
 
 output_basename = my_opts.outputBasename
-evtMax = my_opts.evtMax
 
 # Set input files here or via --inputFiles
 input_files = []
@@ -1206,7 +1203,7 @@ if CONFIG["OutputMode"] == "EDM4Hep":
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = algList,
                 EvtSel = 'NONE',
-                EvtMax = evtMax,
+                EvtMax = 3, # Overridden by the --num-events switch to k4run
                 ExtSvc = svcList,
                 OutputLevel=WARNING
               )

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -58,14 +58,17 @@ cellIDSvc.OutputLevel = INFO
 svcList.append(cellIDSvc)
 
 output_basename = "output"
+evtMax = 3
 
 from k4FWCore.parseArgs import parser
 parser.add_argument("--inputFiles", action="extend", nargs="+", metavar=("file1", "file2"), help="One or multiple input files")
 parser.add_argument("--outputBasename", help="Basename of the output file(s)", default=output_basename)
 parser.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
+parser.add_argument("--evtMax", help="Number of events to process", default=evtMax)
 my_opts = parser.parse_known_args()[0]
 
 output_basename = my_opts.outputBasename
+evtMax = my_opts.evtMax
 
 # Set input files here or via --inputFiles
 input_files = []
@@ -1203,7 +1206,7 @@ if CONFIG["OutputMode"] == "EDM4Hep":
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = algList,
                 EvtSel = 'NONE',
-                EvtMax = 3,
+                EvtMax = evtMax,
                 ExtSvc = svcList,
                 OutputLevel=WARNING
               )


### PR DESCRIPTION
Add an evtMax switch to CLDReconstruction.py, rather than hardcoding 3.

BEGINRELEASENOTES
- CLDReconstruction.py now recognizes the switch --evtMax=N.
ENDRELEASENOTES
