### PR TITLE
cld_steer.py edm4hep output by default

### DIFF
--- a/CLDConfig/cld_steer.py
+++ b/CLDConfig/cld_steer.py
@@ -37,7 +37,7 @@ SIM.macroFile = ""
 ## number of events to simulate, used in batch mode
 SIM.numberOfEvents = 0
 ## Outputfile from the simulation
-SIM.outputFile = "CLD_SIM.root"
+SIM.outputFile = "CLD_SIM.edm4hep.root"
 ## Verbosity use integers from 1(most) to 7(least) verbose
 ## or strings: VERBOSE, DEBUG, INFO, WARNING, ERROR, FATAL, ALWAYS
 SIM.printLevel = 3

--- a/CLDConfig/cld_steer.py
+++ b/CLDConfig/cld_steer.py
@@ -36,8 +36,8 @@ SIM.inputFiles = []
 SIM.macroFile = ""
 ## number of events to simulate, used in batch mode
 SIM.numberOfEvents = 0
-## Outputfile from the simulation,only lcio output is supported
-SIM.outputFile = "dummyOutput.slcio"
+## Outputfile from the simulation
+SIM.outputFile = "CLD_SIM.root"
 ## Verbosity use integers from 1(most) to 7(least) verbose
 ## or strings: VERBOSE, DEBUG, INFO, WARNING, ERROR, FATAL, ALWAYS
 SIM.printLevel = 3


### PR DESCRIPTION

BEGINRELEASENOTES

- Change default output file from lcio to edm4hep format in cld_steer.py
- Remove the comment saying that only lcio is supported in cld_steer.py  

ENDRELEASENOTES