### PR TITLE
Add a flag not to always add the test directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ limitations under the License.
 project(CLDConfig)
 
 include(GNUInstallDirs)
+include(CTest)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@ project(CLDConfig)
 
 include(GNUInstallDirs)
 
-add_subdirectory(test)
-enable_testing()
+if(BUILD_TESTING)
+  add_subdirectory(test)
+  enable_testing()
+endif()
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/CLDConfig/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a flag not to always add the test directory

ENDRELEASENOTES

Because the dependencies are different depending on whether the tests run (`dd4hep`, `k4FWCore`, `k4geo`, etc.) or not.