### PR TITLE
LCFIPlus hotfix: re-enable vertexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _deps
 build/*
 install/*
 .vscode
+*.pyc

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -28,7 +28,7 @@ from py_utils import SequenceLoader
 parser.add_argument("--inputFiles", action="extend", nargs="+", metavar=("file1", "file2"), help="One or multiple input files")
 parser.add_argument("--outputBasename", help="Basename of the output file(s)", default="output")
 parser.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
-parser.add_argument("--enableLCFIPlus", action="store_true", help="Enable LCFIPlus dependent parts", default=False)
+parser.add_argument("--enableLCFIJet", action="store_true", help="Enable LCFIPlus jet clustering parts", default=False)
 reco_args = parser.parse_known_args()[0]
 
 algList = []
@@ -70,7 +70,7 @@ if len(geoservice.detectors) > 1:
 sequenceLoader = SequenceLoader(
     algList,
     # global_vars can be used in sequence-loaded modules without explicit import
-    global_vars={"CONFIG": CONFIG, "geoservice": geoservice},
+    global_vars={"CONFIG": CONFIG, "geoservice": geoservice, "reco_args": reco_args},
 )
 
 if reco_args.inputFiles:
@@ -124,9 +124,7 @@ sequenceLoader.load("Diagnostics/Tracking")
 if not reco_args.trackingOnly:
     sequenceLoader.load("HighLevelReco/PFOSelector")
     sequenceLoader.load("HighLevelReco/JetClusteringOrRenaming")
-    # FIXME: LCFIPlus causes occasional breakage: https://github.com/lcfiplus/LCFIPlus/issues/69
-    if reco_args.enableLCFIPlus:
-        sequenceLoader.load("HighLevelReco/JetAndVertex")
+    sequenceLoader.load("HighLevelReco/JetAndVertex")
 # event number processor, down here to attach the conversion back to edm4hep to it
 algList.append(EventNumber)
 

--- a/CLDConfig/HighLevelReco/JetAndVertex.py
+++ b/CLDConfig/HighLevelReco/JetAndVertex.py
@@ -192,8 +192,12 @@ VertexFinderUnconstrained.Parameters = {
 
 JetAndVertexSequence = [
     VertexFinder,
-    JetClusteringAndRefiner,
 ]
+
+# FIXME: LCFIPlus causes occasional breakage: https://github.com/lcfiplus/LCFIPlus/issues/69
+# due to not adding the jet clustering parameters to every event as PID information
+if reco_args.enableLCFIJet:
+    JetAndVertexSequence.append(JetClusteringAndRefiner)
 
 if CONFIG["VertexUnconstrained"] == "ON":
     JetAndVertexSequence.append(VertexFinderUnconstrained)


### PR DESCRIPTION
the crash should only come from the jet clustering part :crossed_fingers: and after all it is much nicer to have a fitted primary vertex in your event...