### PR TITLE
Require an input file

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -84,6 +84,7 @@ if reco_args.inputFiles:
     read.OutputLevel = INFO
     algList.append(read)
 else:
+    print('WARNING: No input files specified, this will fail')
     read = None
 
 MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -84,7 +84,7 @@ if reco_args.inputFiles:
     read.OutputLevel = INFO
     algList.append(read)
 else:
-    print('WARNING: No input files specified, this will fail')
+    print('WARNING: No input files specified, the CLD Reconstruction will fail')
     read = None
 
 MyAIDAProcessor = MarlinProcessorWrapper("MyAIDAProcessor")


### PR DESCRIPTION
since it's not going to run without but then you'll still have to wait for DD4hep to load the geometry before failing.

BEGINRELEASENOTES
- Print warning on missing input file

ENDRELEASENOTES