### PR TITLE
Add integration time for ECalBarrelEta for CLD_o4_v05

### DIFF
--- a/CLDConfig/Overlay/Overlay.py
+++ b/CLDConfig/Overlay/Overlay.py
@@ -40,7 +40,7 @@ OverlayParameters = {
         "YokeBarrelCollection", "380",
         "YokeEndcapCollection", "380",
         "LumiCalCollection", "380",
-        "ECalBarrelEta", "380",
+        "ECalBarrelEta", "380",  # for CLD_o4_v05 with LAr
      ],
     "PhysicsBX": ["1"],
     "Poisson_random_NOverlay": ["false"],

--- a/CLDConfig/Overlay/Overlay.py
+++ b/CLDConfig/Overlay/Overlay.py
@@ -39,8 +39,8 @@ OverlayParameters = {
         "HCalRingCollection", "380",
         "YokeBarrelCollection", "380",
         "YokeEndcapCollection", "380",
-        "LumiCalCollection", "380"
-        "ECalBarrelEta", "380"
+        "LumiCalCollection", "380",
+        "ECalBarrelEta", "380",
      ],
     "PhysicsBX": ["1"],
     "Poisson_random_NOverlay": ["false"],

--- a/CLDConfig/Overlay/Overlay.py
+++ b/CLDConfig/Overlay/Overlay.py
@@ -40,6 +40,7 @@ OverlayParameters = {
         "YokeBarrelCollection", "380",
         "YokeEndcapCollection", "380",
         "LumiCalCollection", "380"
+        "ECalBarrelEta", "380"
      ],
     "PhysicsBX": ["1"],
     "Poisson_random_NOverlay": ["false"],


### PR DESCRIPTION
Appears here: https://github.com/key4hep/k4geo/blob/main/FCCee/CLD/compact/CLD_o4_v05/LAr_ECalBarrel.xml#L84, and the Overlay algorithm complains even when not overlaying anything.

BEGINRELEASENOTES
- CLDReco/Overlay: Add an integration time for the ECalBarrelEta collection for CLD_o4_v05 

ENDRELEASENOTES