### PR TITLE
Update detector model used for CI and add tests for LCFIJet and `--help`

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -55,7 +55,7 @@ CONFIG = {
 
 from Configurables import GeoSvc, TrackingCellIDEncodingSvc
 geoservice = GeoSvc("GeoSvc")
-geoservice.detectors = [os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o2_v05/CLD_o2_v05.xml"]
+geoservice.detectors = [os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml"]
 geoservice.OutputLevel = INFO
 geoservice.EnableGeant4Geo = False
 svcList.append(geoservice)

--- a/CLDConfig/cld_steer.py
+++ b/CLDConfig/cld_steer.py
@@ -23,7 +23,7 @@ from g4units import mm, GeV, MeV, m, deg
 SIM = DD4hepSimulation()
 
 ## The compact XML file
-SIM.compactFile = ""
+SIM.compactFile = os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml"
 ## Lorentz boost for the crossing angle, in radian!
 SIM.crossingAngleBoost = 0.015
 SIM.enableDetailedShowerMode = True

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ limitations under the License.
 ]]
 include(CTest)
 
-set(DETECTOR $ENV{K4GEO}/FCCee/CLD/compact/FCCee_o1_v04/FCCee_o1_v04.xml)
+set(DETECTOR $ENV{K4GEO}/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml)
 set(CLDConfig_DIR ${CMAKE_CURRENT_LIST_DIR}/../CLDConfig)
 
 add_test(NAME ddsim_lcio

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,3 +49,9 @@ add_test(NAME trkOnly
          COMMAND k4run --trackingOnly --inputFiles=test.edm4hep.root --outputBasename=trkOnly_test_edm4hep CLDReconstruction.py --GeoSvc.detectors=${DETECTOR}
 )
 set_property(TEST trkOnly APPEND PROPERTY DEPENDS ddsim_edm4hep)
+
+add_test(NAME LCFIJet
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND k4run --enableLCFIJet --inputFiles=test.edm4hep.root --outputBasename=trkOnly_test_edm4hep CLDReconstruction.py --GeoSvc.detectors=${DETECTOR}
+)
+set_property(TEST LCFIJet APPEND PROPERTY DEPENDS ddsim_edm4hep)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,3 +55,9 @@ add_test(NAME LCFIJet
          COMMAND k4run --enableLCFIJet --inputFiles=test.edm4hep.root --outputBasename=trkOnly_test_edm4hep CLDReconstruction.py --GeoSvc.detectors=${DETECTOR}
 )
 set_property(TEST LCFIJet APPEND PROPERTY DEPENDS ddsim_edm4hep)
+
+add_test(NAME Help
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND k4run --help CLDReconstruction.py
+)
+set_property(TEST Help APPEND PROPERTY PASS_REGULAR_EXPRESSION "show this help message and exit")


### PR DESCRIPTION
BEGINRELEASENOTES
- Updated detector model used for CI to `CLD_o2_v06` and added tests for LCFIJet and `k4run --help`

ENDRELEASENOTES
