### PR TITLE
cld_steer.py: set SIM.gun.energy to None

### DIFF
--- a/CLDConfig/cld_steer.py
+++ b/CLDConfig/cld_steer.py
@@ -157,7 +157,7 @@ SIM.gun.direction = (0, 0, 1)
 ##     Setting a distribution will set isotrop = True
 ##
 SIM.gun.distribution = None
-SIM.gun.energy = 10000.0
+SIM.gun.energy = None
 
 ##  isotropic distribution for the particle gun
 ##


### PR DESCRIPTION
Otherwise it overwrites ` --gun.momentumMin/Max`

BEGINRELEASENOTES
- cld_steer.py: set SIM.gun.energy to None

ENDRELEASENOTES
