### PR TITLE
Refactor III

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -99,7 +99,6 @@ EventNumber.Parameters = {
                           "HowOften": ["1"]
                           }
 
-# TODO: put this somewhere else, needs to be in front of the output for now :(
 # setup AIDA histogramming and add eventual background overlay
 algList.append(MyAIDAProcessor)
 sequenceLoader.load("Overlay/Overlay")

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -165,7 +165,7 @@ if CONFIG["OutputMode"] == "EDM4Hep":
     lcioConvTool.collNameMapping = {
         "MCParticle": "MCParticles"
     }
-    lcioConvTool.OutputLevel = DEBUG
+    lcioConvTool.OutputLevel = WARNING
 # attach to the last non output processor
     EventNumber.Lcio2EDM4hepTool = lcioConvTool
 

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -33,7 +33,7 @@ parser_group.add_argument("--inputFiles", action="extend", nargs="+", metavar=("
 parser_group.add_argument("--outputBasename", help="Basename of the output file(s)", default="output")
 parser_group.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
 parser_group.add_argument("--enableLCFIJet", action="store_true", help="Enable LCFIPlus jet clustering parts", default=False)
-parser_group.add_argument("--compactFile", help="Compact detector file to use", type=str, default=os.environ["K4GEO"] + "/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml")
+parser_group.add_argument("--compactFile", help="Compact detector file to use", type=str, default=os.environ["K4GEO"] + "/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml")
 tracking_group = parser_group.add_mutually_exclusive_group()
 tracking_group.add_argument("--conformalTracking", action="store_true", default=True, help="Use conformal tracking pattern recognition")
 tracking_group.add_argument("--truthTracking", action="store_true", default=False, help="Cheat tracking pattern recognition")

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -28,11 +28,12 @@ import ROOT
 ROOT.gROOT.SetBatch(True)
 
 
-parser.add_argument("--inputFiles", action="extend", nargs="+", metavar=("file1", "file2"), help="One or multiple input files")
-parser.add_argument("--outputBasename", help="Basename of the output file(s)", default="output")
-parser.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
-parser.add_argument("--enableLCFIJet", action="store_true", help="Enable LCFIPlus jet clustering parts", default=False)
-parser.add_argument("--compactFile", help="Compact detector file to use", type=str, default=os.environ["K4GEO"] + "/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml")
+parser_group = parser.add_argument_group("CLDReconstruction.py custom options")
+parser_group.add_argument("--inputFiles", action="extend", nargs="+", metavar=("file1", "file2"), help="One or multiple input files")
+parser_group.add_argument("--outputBasename", help="Basename of the output file(s)", default="output")
+parser_group.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
+parser_group.add_argument("--enableLCFIJet", action="store_true", help="Enable LCFIPlus jet clustering parts", default=False)
+parser_group.add_argument("--compactFile", help="Compact detector file to use", type=str, default=os.environ["K4GEO"] + "/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml")
 reco_args = parser.parse_known_args()[0]
 
 algList = []

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -34,6 +34,9 @@ parser_group.add_argument("--outputBasename", help="Basename of the output file(
 parser_group.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
 parser_group.add_argument("--enableLCFIJet", action="store_true", help="Enable LCFIPlus jet clustering parts", default=False)
 parser_group.add_argument("--compactFile", help="Compact detector file to use", type=str, default=os.environ["K4GEO"] + "/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml")
+tracking_group = parser_group.add_mutually_exclusive_group()
+tracking_group.add_argument("--conformalTracking", action="store_true", default=True, help="Use conformal tracking pattern recognition")
+tracking_group.add_argument("--truthTracking", action="store_true", default=False, help="Cheat tracking pattern recognition")
 reco_args = parser.parse_known_args()[0]
 
 algList = []
@@ -47,8 +50,6 @@ CONFIG = {
              "CalorimeterIntegrationTimeWindowChoices": ["10ns", "400ns"],
              "Overlay": "False",
              "OverlayChoices": ["False", "91GeV", "365GeV"],
-             "Tracking": "Conformal",
-             "TrackingChoices": ["Truth", "Conformal"],
              "VertexUnconstrained": "OFF",
              "VertexUnconstrainedChoices": ["ON", "OFF"],
              "OutputMode": "EDM4Hep",
@@ -108,9 +109,9 @@ sequenceLoader.load("Overlay/Overlay")
 sequenceLoader.load("Tracking/TrackingDigi")
 
 # tracking
-if CONFIG["Tracking"] == "Truth":
+if reco_args.truthTracking:
     sequenceLoader.load("Tracking/TruthTracking")
-elif CONFIG["Tracking"] == "Conformal":
+elif reco_args.conformalTracking:
     sequenceLoader.load("Tracking/ConformalTracking")
 
 sequenceLoader.load("Tracking/Refit")

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -22,7 +22,7 @@ from Gaudi.Configuration import INFO, WARNING, DEBUG
 from Configurables import k4DataSvc, MarlinProcessorWrapper
 from k4MarlinWrapper.inputReader import create_reader, attach_edm4hep2lcio_conversion
 from k4FWCore.parseArgs import parser
-from py_utils import SequenceLoader
+from py_utils import SequenceLoader, attach_lcio2edm4hep_conversion
 
 import ROOT
 ROOT.gROOT.SetBatch(True)
@@ -159,16 +159,6 @@ if CONFIG["OutputMode"] == "LCIO":
     algList.append(Output_DST)
 
 if CONFIG["OutputMode"] == "EDM4Hep":
-    from Configurables import Lcio2EDM4hepTool
-    lcioConvTool = Lcio2EDM4hepTool("lcio2EDM4hep")
-    lcioConvTool.convertAll = True
-    lcioConvTool.collNameMapping = {
-        "MCParticle": "MCParticles"
-    }
-    lcioConvTool.OutputLevel = WARNING
-# attach to the last non output processor
-    EventNumber.Lcio2EDM4hepTool = lcioConvTool
-
     from Configurables import PodioOutput
     out = PodioOutput("PodioOutput", filename = f"{reco_args.outputBasename}_edm4hep.root")
     out.outputCommands = ["keep *"]
@@ -176,6 +166,9 @@ if CONFIG["OutputMode"] == "EDM4Hep":
 
 # We need to convert the inputs in case we have EDM4hep input
 attach_edm4hep2lcio_conversion(algList, read)
+
+# We need to convert the outputs in case we have EDM4hep output
+attach_lcio2edm4hep_conversion(algList)
 
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = algList,

--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -32,6 +32,7 @@ parser.add_argument("--inputFiles", action="extend", nargs="+", metavar=("file1"
 parser.add_argument("--outputBasename", help="Basename of the output file(s)", default="output")
 parser.add_argument("--trackingOnly", action="store_true", help="Run only track reconstruction", default=False)
 parser.add_argument("--enableLCFIJet", action="store_true", help="Enable LCFIPlus jet clustering parts", default=False)
+parser.add_argument("--compactFile", help="Compact detector file to use", type=str, default=os.environ["K4GEO"] + "/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml")
 reco_args = parser.parse_known_args()[0]
 
 algList = []
@@ -55,7 +56,7 @@ CONFIG = {
 
 from Configurables import GeoSvc, TrackingCellIDEncodingSvc
 geoservice = GeoSvc("GeoSvc")
-geoservice.detectors = [os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml"]
+geoservice.detectors = [reco_args.compactFile]
 geoservice.OutputLevel = INFO
 geoservice.EnableGeant4Geo = False
 svcList.append(geoservice)

--- a/CLDConfig/HighLevelReco/JetClusteringOrRenaming.py
+++ b/CLDConfig/HighLevelReco/JetClusteringOrRenaming.py
@@ -25,7 +25,7 @@ RenameCollection.OutputLevel = WARNING
 RenameCollection.ProcessorType = "MergeCollections"
 RenameCollection.Parameters = {
                                "CollectionParameterIndex": ["0"],
-                               "InputCollectionIDs": [],
+                               "InputCollectionIDs": ["0"],
                                "InputCollections": ["PandoraPFOs"],
                                "OutputCollection": ["PFOsFromJets"]
                                }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,24 @@ add_test(NAME LCFIJet
 )
 set_property(TEST LCFIJet APPEND PROPERTY DEPENDS ddsim_edm4hep)
 
+add_test(NAME tracking_truth
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND k4run --trackingOnly --truthTracking --inputFiles=test.edm4hep.root --outputBasename=trkOnly_truth_test_edm4hep CLDReconstruction.py --GeoSvc.detectors=${DETECTOR}
+)
+set_property(TEST tracking_truth APPEND PROPERTY DEPENDS ddsim_edm4hep)
+
+add_test(NAME tracking_conformal
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND k4run --trackingOnly --conformalTracking --inputFiles=test.edm4hep.root --outputBasename=trkOnly_conformal_test_edm4hep CLDReconstruction.py --GeoSvc.detectors=${DETECTOR}
+)
+set_property(TEST tracking_conformal APPEND PROPERTY DEPENDS ddsim_edm4hep)
+
+add_test(NAME tracking_both
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND k4run --trackingOnly --conformalTracking --truthTracking CLDReconstruction.py
+)
+set_property(TEST tracking_both APPEND PROPERTY PASS_REGULAR_EXPRESSION "error: argument --truthTracking: not allowed with argument --conformalTracking")
+
 add_test(NAME Help
          WORKING_DIRECTORY ${CLDConfig_DIR}
          COMMAND k4run --help CLDReconstruction.py

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ limitations under the License.
 ]]
 include(CTest)
 
-set(DETECTOR $ENV{K4GEO}/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml)
+set(DETECTOR $ENV{K4GEO}/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml)
 set(CLDConfig_DIR ${CMAKE_CURRENT_LIST_DIR}/../CLDConfig)
 
 add_test(NAME ddsim_lcio


### PR DESCRIPTION
Another batch of refactoring.

BEGINRELEASENOTES
- Reduced default output verbosities
-  Added a function to conditionally attach output converter if needed
- Wrapped outputs to lcio and edm4hep in a generic function
- Also adds future possibility of DST ouput for edm4hep
- Changed default edm4hep file ending from `_edm4hep.root` to `.edm4hep.root`
- Added configuration arguments `--compactFile, --conformalTracking, --truthTracking`

ENDRELEASENOTES

The edm4hep DST output will only fully work once we have https://github.com/key4hep/k4FWCore/issues/226 so it is commented out for the moment.
