### PR TITLE
add ddsim steering file for CLD o3 (with ARC)

### DIFF
--- a/CLDConfig/cld_arc_steer.py
+++ b/CLDConfig/cld_arc_steer.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File: cld_arc_steer.py
+# Description: this file extends the ddsim steering file used for CLD
+#              with the specifications to run the ARC subdetector
+
+# First, load cld steering file
+
+from cld_steer import *
+# change the compact file to the CLD option 3 (which contains ARC)
+SIM.compactFile = os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o3_v01/CLD_o3_v01.xml"
+
+# Second, define specifications for ARC:
+
+# Register optical physics and Cerenkov process to the default physics
+def setupCerenkov(kernel):
+        from DDG4 import PhysicsList
+
+        seq = kernel.physicsList()
+        cerenkov = PhysicsList(kernel, "Geant4CerenkovPhysics/CerenkovPhys")
+        cerenkov.MaxNumPhotonsPerStep = 10
+        cerenkov.MaxBetaChangePerStep = 10.0
+        cerenkov.TrackSecondariesFirst = False
+        cerenkov.VerboseLevel = 0
+        cerenkov.enableUI()
+        seq.adopt(cerenkov)
+        ph = PhysicsList(kernel, "Geant4OpticalPhotonPhysics/OpticalGammaPhys")
+        ph.addParticleConstructor("G4OpticalPhoton")
+        ph.VerboseLevel = 0
+        ph.BoundaryInvokeSD = True
+        ph.enableUI()
+        seq.adopt(ph)
+        return None
+SIM.physics.setupUserPhysics(setupCerenkov)
+
+# Associate the Geant4OpticalTrackerAction to these detectors
+# this action register total energy of the opt photon as a single hit
+# and kills the optical photon, so no time is wasted tracking them
+SIM.action.mapActions["ARCBARREL"] = "Geant4OpticalTrackerAction"
+SIM.action.mapActions["ARCENDCAP"] = "Geant4OpticalTrackerAction"
+
+# Define filter, so detector is only sensitive to optical photons
+SIM.filter.filters["opticalphotons"] = dict(
+        name="ParticleSelectFilter/OpticalPhotonSelector",
+        parameter={"particle": "opticalphoton"},
+        )
+SIM.filter.mapDetFilter["ARCBARREL"] = "opticalphotons"
+SIM.filter.mapDetFilter["ARCENDCAP"] = "opticalphotons"
+

--- a/CLDConfig/cld_arc_steer.py
+++ b/CLDConfig/cld_arc_steer.py
@@ -15,10 +15,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 # File: cld_arc_steer.py
 # Description: this file extends the ddsim steering file used for CLD
 #              with the specifications to run the ARC subdetector
+#
 
 # First, load cld steering file
 
@@ -62,4 +64,3 @@ SIM.filter.filters["opticalphotons"] = dict(
         )
 SIM.filter.mapDetFilter["ARCBARREL"] = "opticalphotons"
 SIM.filter.mapDetFilter["ARCENDCAP"] = "opticalphotons"
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,11 @@ add_test(NAME ddsim_lcio
          COMMAND ddsim -S cld_steer.py -N 3 --inputFile ../test/yyxyev_000.stdhep --outputFile test.slcio --compactFile ${DETECTOR}
 )
 
+add_test(NAME ddsim_cld_arc
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND ddsim -S cld_arc_steer.py -N 10 -G --gun.direction "1 0 0"
+)
+
 # FIXME: need to call k4run from CLDConfig dir where the pandora config lives
 add_test(NAME lcio_input
          WORKING_DIRECTORY ${CLDConfig_DIR}


### PR DESCRIPTION

BEGINRELEASENOTES
- DDsim steering file for CLD o3 (with ARC), which runs the cld_steering.py, and adds optical physics and SD action and filter for ARC. 
 
ENDRELEASENOTES

Hi,

I have tested the full CLD o3 with this steering file. There is the hit pattern of optical photons in ARC of 1 and 10 events respectively
![Screenshot from 2024-07-26 15-50-51](https://github.com/user-attachments/assets/f93e834d-9312-4cd1-945f-20d30d8d6bd1)
![Screenshot from 2024-07-26 15-49-17](https://github.com/user-attachments/assets/138df9b2-2e88-49d0-a1a7-f6c6cc65f9a2)

I have run the following command to produce the plots:
```
ddsim --steeringFile cld_arc_steer.py -N 10 -G --gun.direction "1 0 0"
root CLD_SIM.edm4hep.root
events->Draw("ArcCollection.position.x:ArcCollection.position.z","","",1)
```

Please let me know if something else should be changed :)