### PR TITLE
Use CLD_o2_v07 instead of CLD_o2_v06 in the sim steering file

### DIFF
--- a/CLDConfig/cld_steer.py
+++ b/CLDConfig/cld_steer.py
@@ -23,7 +23,7 @@ from g4units import mm, GeV, MeV, m, deg
 SIM = DD4hepSimulation()
 
 ## The compact XML file
-SIM.compactFile = os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o2_v06/CLD_o2_v06.xml"
+SIM.compactFile = os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml"
 ## Lorentz boost for the crossing angle, in radian!
 SIM.crossingAngleBoost = 0.015
 SIM.enableDetailedShowerMode = True


### PR DESCRIPTION
BEGINRELEASENOTES
- Use CLD_o2_v07 instead of CLD_o2_v06 in the sim steering file. It's already being used in the reconstruction steering file, so it makes sense to use the same geometry for simulation.

ENDRELEASENOTES

Note that the documentation in https://fcc-ee-detector-full-sim.docs.cern.ch/CLD/ also has to be updated.