### PR TITLE
cld_steer: use tracking volume

### DIFF
--- a/CLDConfig/cld_arc_steer.py
+++ b/CLDConfig/cld_arc_steer.py
@@ -64,3 +64,6 @@ SIM.filter.filters["opticalphotons"] = dict(
         )
 SIM.filter.mapDetFilter["ARCBARREL"] = "opticalphotons"
 SIM.filter.mapDetFilter["ARCENDCAP"] = "opticalphotons"
+
+# explicitly use the cylinder volume base particle handler
+SIM.part.userParticleHandler = "Geant4TCUserParticleHandler"

--- a/CLDConfig/cld_steer.py
+++ b/CLDConfig/cld_steer.py
@@ -199,6 +199,8 @@ SIM.output.random = 6
 ## Configuration for the Particle Handler/ MCTruth treatment
 ################################################################################
 
+SIM.part.userParticleHandler = "Geant4TVUserParticleHandler"
+
 ##  Keep all created particles
 SIM.part.keepAllParticles = False
 


### PR DESCRIPTION

BEGINRELEASENOTES
-  Use `Geant4TVUserParticleHandler` by default in `cld_steer.py`

ENDRELEASENOTES

Now that the default is `CLD_o2_v07` we can also default to the particle handler that uses the custom tracking region instead of just a cylinder.
