### PR TITLE
Fix paths in CLDReconstruction.xml and add a test running with Marlin

### DIFF
--- a/CLDConfig/CLDReconstruction.xml
+++ b/CLDConfig/CLDReconstruction.xml
@@ -123,7 +123,7 @@
     <!--Name of the DD4hep compact xml file to load-->
     <parameter name="EncodingStringParameter"> GlobalTrackerReadoutID </parameter>
     <parameter name="DD4hepXMLFile" type="string">
-      /cvmfs/clicdp.cern.ch/iLCSoft/builds/nightly/x86_64-slc6-gcc62-opt/lcgeo/HEAD/FCCee/compact/FCCee_o1_v04/FCCee_o1_v04.xml
+      /cvmfs/sw.hsf.org/key4hep/releases/2024-10-03/x86_64-almalinux9-gcc14.2.0-opt/k4geo/0.21-d5gbnd/share/k4geo/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml
     </parameter>
   </processor>
 

--- a/CLDConfig/CLDReconstruction.xml
+++ b/CLDConfig/CLDReconstruction.xml
@@ -915,7 +915,7 @@
     <parameter name="StripSplittingOn" type="int">0 </parameter>
 
     <processor name="MyDDMarlinPandora_10ns" type="DDPandoraPFANewProcessor">
-      <parameter name="PandoraSettingsXmlFile" type="String"> PandoraSettingsFCCee/PandoraSettingsDefault.xml </parameter>
+      <parameter name="PandoraSettingsXmlFile" type="String"> PandoraSettingsCLD/PandoraSettingsDefault.xml </parameter>
       <parameter name="SoftwareCompensationWeights" type="FloatVec">2.40821 -0.0515852 0.000711414 -0.0254891 -0.0121505 -1.63084e-05 0.062149 0.0690735 -0.223064</parameter>
       <!-- Calibration constants -->
       <parameter name="ECalToMipCalibration" type="float">175.439</parameter>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,3 +84,8 @@ add_test(NAME Help
          COMMAND k4run --help CLDReconstruction.py
 )
 set_property(TEST Help APPEND PROPERTY PASS_REGULAR_EXPRESSION "show this help message and exit")
+
+add_test(NAME marlin
+         WORKING_DIRECTORY ${CLDConfig_DIR}
+         COMMAND Marlin --global.LCIOInputFiles=test.slcio --InitDD4hep.DD4hepXMLFile=${DETECTOR} CLDReconstruction.xml
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,3 +89,4 @@ add_test(NAME marlin
          WORKING_DIRECTORY ${CLDConfig_DIR}
          COMMAND Marlin --global.LCIOInputFiles=test.slcio --InitDD4hep.DD4hepXMLFile=${DETECTOR} CLDReconstruction.xml
 )
+set_property(TEST marlin APPEND PROPERTY DEPENDS ddsim_lcio)


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the path to the pandora settings XML file
- Fix the path to the default CLD XML file, use CLD_o2_v07
- Add a test running with Marlin

ENDRELEASENOTES