### PR TITLE
Add a comment for the new overlay integration time for CLD+ARC

### DIFF
--- a/CLDConfig/Overlay/Overlay.py
+++ b/CLDConfig/Overlay/Overlay.py
@@ -41,7 +41,7 @@ OverlayParameters = {
         "YokeEndcapCollection", "380",
         "LumiCalCollection", "380",
         "ECalBarrelEta", "380",  # for CLD_o4_v05 with LAr
-        "ArcCollection", "380",  # for CLD_o3_v01 with ARC        
+        "ArcCollection", "380",  # for CLD_o3_v01 with ARC
      ],
     "PhysicsBX": ["1"],
     "Poisson_random_NOverlay": ["false"],

--- a/CLDConfig/Overlay/Overlay.py
+++ b/CLDConfig/Overlay/Overlay.py
@@ -41,6 +41,7 @@ OverlayParameters = {
         "YokeEndcapCollection", "380",
         "LumiCalCollection", "380",
         "ECalBarrelEta", "380",  # for CLD_o4_v05 with LAr
+        "ArcCollection", "380",  # for CLD_o3_v01 with ARC        
      ],
     "PhysicsBX": ["1"],
     "Poisson_random_NOverlay": ["false"],


### PR DESCRIPTION
BEGINRELEASENOTES

CLDReconstruction: Adding overlay integration time for ARC to make code compatible with `CLD_03_v01`, fixes #66 

ENDRELEASENOTES
