### PR TITLE
Set LANGUAGES to CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ]]
-project(CLDConfig)
+project(CLDConfig LANGUAGES NONE)
 
 include(GNUInstallDirs)
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ]]
-project(CLDConfig LANGUAGES NONE)
+project(CLDConfig LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include(CTest)


### PR DESCRIPTION
BEGINRELEASENOTES
- Set LANGUAGES to CXX

ENDRELEASENOTES

Spack is more picky now and language dependencies have to be specified in the recipe. `CXX` is not needed but it's not possible to remove it because determining `CMAKE_INSTALL_DATADIR` that is used for installation needs a language to be specified.