### PR TITLE
Add a minimum cmake version to prevent a warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ include(CTest)
 
 if(BUILD_TESTING)
   add_subdirectory(test)
-  enable_testing()
 endif()
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/CLDConfig/ DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ]]
+
+cmake_minimum_required(VERSION 3.15)
+
 project(CLDConfig LANGUAGES CXX)
 
 include(GNUInstallDirs)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,8 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ]]
-include(CTest)
-
 set(DETECTOR $ENV{K4GEO}/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml)
 set(CLDConfig_DIR ${CMAKE_CURRENT_LIST_DIR}/../CLDConfig)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add a minimum cmake version to prevent a warning
- Remove redundant lines, `enable_testing()` is not needed and don't include CTest twice

ENDRELEASENOTES

This is the warning:

```
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as
-- Configuring done (24.3s)

    cmake_minimum_required(VERSION 3.30)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.
```

I chose 3.15 for no reason. It could be any other, I don't think this repository uses any recent features.