### PR TITLE
Fix imports when `:` is not in `PYTHONPATH`

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -22,6 +22,8 @@ from Gaudi.Configuration import INFO, WARNING, DEBUG
 from Gaudi.Configurables import EventDataSvc, MarlinProcessorWrapper, GeoSvc, TrackingCellIDEncodingSvc
 from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
+import sys
+sys.path.append('.')
 from py_utils import SequenceLoader, parse_collection_patch_file
 from k4MarlinWrapper.io_helpers import IOHandlerHelper
 

--- a/CLDConfig/cld_arc_steer.py
+++ b/CLDConfig/cld_arc_steer.py
@@ -24,6 +24,8 @@
 
 # First, load cld steering file
 
+import sys
+sys.path.append('.')
 from cld_steer import *
 # change the compact file to the CLD option 3 (which contains ARC)
 SIM.compactFile = os.environ["K4GEO"]+"/FCCee/CLD/compact/CLD_o3_v01/CLD_o3_v01.xml"


### PR DESCRIPTION
We rely on `:` being in `PYTHONPATH`, which means that Python will look into the current directory. This is important because we have steering files that either through `ddsim` or `k4run` exec other files that are in different directories. Without `:`, imports in the steering files from the current directory don't work. Since I am not sure that the best option is to always add `:` at the end of `PYTHONPATH` and the LCG stacks don't have it by default, let's fix it in the few places that it happens. It also improves using local packages since this is something that I have spent some time on in the past when setting my local environment and it wouldn't work.

BEGINRELEASENOTES
- CLDReconstruction.py, cld_arc_steer.py: Fix importing local files when local directory is not part of the `PYTHONPATH` due to `:` not being at the end of the `PYTHONPATH` variable.

ENDRELEASENOTES