### PR TITLE
Make all paths relative

### DIFF
--- a/CLDConfig/CLDReconstruction.py
+++ b/CLDConfig/CLDReconstruction.py
@@ -23,7 +23,8 @@ from Gaudi.Configurables import EventDataSvc, MarlinProcessorWrapper, GeoSvc, Tr
 from k4FWCore import ApplicationMgr, IOSvc
 from k4FWCore.parseArgs import parser
 import sys
-sys.path.append('.')
+base_dir = os.path.dirname(__file__)
+sys.path.append(base_dir)
 from py_utils import SequenceLoader, parse_collection_patch_file
 from k4MarlinWrapper.io_helpers import IOHandlerHelper
 
@@ -58,7 +59,7 @@ CONFIG = {
              "OutputModeChoices": ["LCIO", "EDM4hep"] #, "both"] FIXME: both is not implemented yet
 }
 
-REC_COLLECTION_CONTENTS_FILE = "collections_rec_level.txt" # file with the collections to be patched in when writing from LCIO to EDM4hep
+REC_COLLECTION_CONTENTS_FILE = f"{base_dir}/collections_rec_level.txt" # file with the collections to be patched in when writing from LCIO to EDM4hep
 
 geoservice = GeoSvc("GeoSvc")
 geoservice.detectors = [reco_args.compactFile]
@@ -90,6 +91,7 @@ sequenceLoader = SequenceLoader(
     global_vars={"CONFIG": CONFIG, "geoservice": geoservice, "reco_args": reco_args,
                  "BEAM_SPOT_SIZES": BEAM_SPOT_SIZES,
                  },
+    base_dir=base_dir,
 )
 
 io_handler = IOHandlerHelper(algList, iosvc)

--- a/CLDConfig/ParticleFlow/Pandora.py
+++ b/CLDConfig/ParticleFlow/Pandora.py
@@ -20,7 +20,9 @@ from Gaudi.Configuration import WARNING
 from Configurables import MarlinProcessorWrapper
 
 import sys
+import os
 
+dir_path = os.path.dirname(__file__)
 
 MyDDMarlinPandoraParameters = {
                                      "FinalEnergyDensityBin": ["110."],
@@ -112,7 +114,7 @@ MyDDMarlinPandora.Parameters = MyDDMarlinPandoraParameters.copy()
 if CONFIG["CalorimeterIntegrationTimeWindow"] == "10ns":
 
     MyDDMarlinPandora.Parameters |= {
-                                "PandoraSettingsXmlFile": ["PandoraSettingsCLD/PandoraSettingsDefault.xml"],
+                                "PandoraSettingsXmlFile": [f"{dir_path}/../PandoraSettingsCLD/PandoraSettingsDefault.xml"],
                                 "SoftwareCompensationWeights": ["2.40821", "-0.0515852", "0.000711414", "-0.0254891", "-0.0121505", "-1.63084e-05", "0.062149", "0.0690735", "-0.223064"],
                                 "ECalToMipCalibration": ["175.439"],
                                 "HCalToMipCalibration": ["45.6621"],
@@ -131,7 +133,7 @@ if CONFIG["CalorimeterIntegrationTimeWindow"] == "10ns":
 elif CONFIG["CalorimeterIntegrationTimeWindow"] == "400ns":
 
     MyDDMarlinPandora.Parameters |= {
-                               "PandoraSettingsXmlFile": ["PandoraSettingsCLD/PandoraSettingsDefault_400nsCalTimeWindow.xml"],
+                               "PandoraSettingsXmlFile": [f"{dir_path}/../PandoraSettingsCLD/PandoraSettingsDefault_400nsCalTimeWindow.xml"],
                                "SoftwareCompensationWeights": ["2.43375", "-0.0430951", "0.000244914", "-0.145478", "-0.00044577", "-8.37222e-05", "0.237484", "0.243491", "-0.0713701"],
                                "ECalToMipCalibration": ["175.439"],
                                "HCalToMipCalibration": ["49.7512"],

--- a/CLDConfig/ParticleFlow/Pandora.py
+++ b/CLDConfig/ParticleFlow/Pandora.py
@@ -21,8 +21,17 @@ from Configurables import MarlinProcessorWrapper
 
 import sys
 import os
+from pathlib import Path
 
-dir_path = os.path.dirname(__file__)
+
+dir_path = Path(os.path.dirname(__file__))
+cwd = Path.cwd()
+
+help_only = "-h" in sys.argv or "--help" in sys.argv
+if cwd != dir_path.parent and not help_only:
+    print(f"Running Pandora is only possible when k4run is called from the directory: {dir_path.parent}")
+    sys.exit(1)
+
 
 MyDDMarlinPandoraParameters = {
                                      "FinalEnergyDensityBin": ["110."],

--- a/CLDConfig/py_utils.py
+++ b/CLDConfig/py_utils.py
@@ -78,7 +78,7 @@ class SequenceLoader:
     """
 
     def __init__(
-        self, alg_list: list, global_vars: Optional[Dict[str, Any]] = None
+        self, alg_list: list, global_vars: Optional[Dict[str, Any]] = None, base_dir: Optional[str] = None
     ) -> None:
         """Initialize the SequenceLoader
 
@@ -93,9 +93,11 @@ class SequenceLoader:
                 variables for the sequences. Defaults to None. The keys in this
                 dictionary will be the available variables in the imported
                 module and the values will be the values of these variables.
+            base_dir (Optional[str]): path from which the sequences will be loaded.
         """
         self.alg_list = alg_list
         self.global_vars = global_vars
+        self.base_dir = base_dir or "."
 
     def load(self, sequence: str) -> None:
         """Loads a sequence algorithm from a specified Python file and appends
@@ -118,7 +120,7 @@ class SequenceLoader:
             sequence of algorithms that is defined in `TrackingDigiSequence` in
             that file to the alg_list
         """
-        filename = f"{sequence}.py"
+        filename = f"{self.base_dir}/{sequence}.py"
         seq_name = f"{sequence.split('/')[-1]}Sequence"
 
         seq_module = import_from(

--- a/CLDConfig/py_utils.py
+++ b/CLDConfig/py_utils.py
@@ -19,7 +19,6 @@
 import os
 from typing import Union, Optional, Dict, Any, List
 import importlib.util
-import importlib.abc
 from importlib.machinery import SourceFileLoader
 
 
@@ -78,7 +77,10 @@ class SequenceLoader:
     """
 
     def __init__(
-        self, alg_list: list, global_vars: Optional[Dict[str, Any]] = None, base_dir: Optional[str] = None
+        self,
+        alg_list: list,
+        global_vars: Optional[Dict[str, Any]] = None,
+        base_dir: Optional[str] = None,
     ) -> None:
         """Initialize the SequenceLoader
 
@@ -130,7 +132,6 @@ class SequenceLoader:
 
         seq = getattr(seq_module, seq_name)
         self.alg_list.extend(seq)
-
 
 
 def parse_collection_patch_file(patch_file: Union[str, os.PathLike]) -> List[str]:


### PR DESCRIPTION

BEGINRELEASENOTES
- Make paths for sequences, collection patch file and Pandora configuration relative. Running with Pandora will still require calling k4run from the correct directory, but it now prints a warning in that case.
ENDRELEASENOTES

First patch on the journey to fix #88 

Running the reconstruction with Pandora from a different directory still fails because of https://github.com/key4hep/CLDConfig/blob/691ef7e876c76d444cbc89b9cbf70214b46da0f8/CLDConfig/PandoraSettingsCLD/PandoraSettingsDefault.xml#L100

Handling this without creating a new file every time would need an extension of Pandora and its API to offer a copy of [`Pandora::ReadSettings`](https://github.com/PandoraPFA/PandoraSDK/blob/4777745476b93ba03bfb7f527b6c90574485a14e/src/Pandora/Pandora.cc#L138) that takes the XML as a string directly. Then we could dynamically rewrite the path from our side. This will be left for a future PR.